### PR TITLE
Add spell loading animation.

### DIFF
--- a/portfolio/spellbook/static/spellbook/css/style.css
+++ b/portfolio/spellbook/static/spellbook/css/style.css
@@ -71,7 +71,7 @@ footer {
     margin-bottom: -5px;
 }
 
-.spell-detail-content .spell-name {
+.spell-detail-content h3 {
     font-size: 1.5em;
     margin-top: 0;
     padding-top: 15px;
@@ -160,4 +160,78 @@ footer {
 
 .search button {
     margin-bottom: 5px;
+}
+
+.loader {
+    height: 100px;
+}
+
+
+/*  Lines below are for spell loading animation
+    This was adapted from code found at:
+    https://martinwolf.org/blog/2015/01/pure-css-savingloading-dots-animation
+*/
+@keyframes blink {
+    /**
+     * At the start of the animation the dot
+     * has an opacity of .2
+     */
+    0% {
+      opacity: .2;
+    }
+    /**
+     * At 20% the dot is fully visible and
+     * then fades out slowly
+     */
+    20% {
+      opacity: 1;
+    }
+    /**
+     * Until it reaches an opacity of .2 and
+     * the animation can start again
+     */
+    100% {
+      opacity: .2;
+    }
+}
+
+.loading span {
+    /**
+     * Use the blink animation, which is defined above
+     */
+    animation-name: blink;
+    /**
+     * The animation should take 1.4 seconds
+     */
+    animation-duration: 1.4s;
+    /**
+     * It will repeat itself forever
+     */
+    animation-iteration-count: infinite;
+    /**
+     * This makes sure that the starting style (opacity: .2)
+     * of the animation is applied before the animation starts.
+     * Otherwise we would see a short flash or would have
+     * to set the default styling of the dots to the same
+     * as the animation. Same applies for the ending styles.
+     */
+    animation-fill-mode: both;
+}
+
+.loading span:nth-child(2) {
+    /**
+     * Starts the animation of the third dot
+     * with a delay of .2s, otherwise all dots
+     * would animate at the same time
+     */
+    animation-delay: .2s;
+}
+
+.loading span:nth-child(3) {
+    /**
+     * Starts the animation of the third dot
+     * with a delay of .4s, otherwise all dots
+     * would animate at the same time
+     */
+    animation-delay: .4s;
 }

--- a/portfolio/spellbook/static/spellbook/js/spells.js
+++ b/portfolio/spellbook/static/spellbook/js/spells.js
@@ -89,6 +89,7 @@ function setSpellLevelListener () {
 }
 
 function loadSpellDetail (target) {
+    target.append("<div class='loader spell-detail-content'><h3 class='loading spell-name'>Loading<span>.</span><span>.</span><span>.</span></h3></div>")
     $.ajax({
         method: "post",
         url: "/spellbook/get_spell_detail",
@@ -96,6 +97,7 @@ function loadSpellDetail (target) {
             spell: target.attr('id'),
         },
         success: function(data){
+            $(".loader").remove()
             target.append(data)
         }
     });


### PR DESCRIPTION
Occasionally spells can take a little bit to load. The delay should be minor but some feedback that something is happening in response to a click should be given to the user.

The addition of this loading animation gives the user immediate feedback that something is happening while keeping the UI minimalistic. 